### PR TITLE
Add an inline comment with ref source

### DIFF
--- a/pcd.yaml
+++ b/pcd.yaml
@@ -12,23 +12,28 @@ physical_constants_dictionary:
         With Formulas, Graphs, and Mathematical Tables, DOC/National Bureau of Standards,
         Applied Mathematics Series, 55, June 1964.
       "
+      short_citation: Abramowitz A., Stegun I.A., (1964)
     CODATA2022:
       description: "CODATA 2022 recommended values of fundamental physical constants"
       citation: "
         Mohr, P.J., Newell, D.B., Taylor, B.N. and Tiesinga, E., Rev. Mod. Phys., 97,
         025002 (2025); doi: 10.1103/RevModPhys.97.025002
       "
+      short_citation: CODATA (2022)
     moritz_2000:
       description: "Geodetic Reference System 1980 for Earth's physical parameters"
       citation: "
         Moritz, H, Geodetic Reference System 1980. J. Geodesy, 74 128-133, 2000.
       "
+      short_citation: Moritz H., et al., (2000)
     kopp_2005:
       description: "Total solar irradiance measurements from SORCE TIM instrument"
       citation: "
         Kopp, G., Lawrence, G., and Rottman, G., The Total Irradiance Monitor (TIM):
         Science results, Sol. Phys., 230, 129–139, 2005. doi:10.1007/s11207-005-7433-9.
       "
+      short_citation: Kopp G., et al., (2000)
+
     wagner_2002:
       description: "IAPWS-95 formulation for thermodynamic properties of water"
       citation: "
@@ -36,6 +41,7 @@ physical_constants_dictionary:
         Properties of Ordinary Water Substance for General and Scientific Use,
         J. Phys. Chem. Ref. Data, 31, 387-535, 2002.
       "
+      short_citation: Wagner W., Pruss A., (2000)
 
   set:
     - mathematical:

--- a/tools/generate_source.py
+++ b/tools/generate_source.py
@@ -94,7 +94,7 @@ def write_footer(ofile,lang):
         raise RuntimeError(f'Missing implementation for language {lang}')
 
 ###############################################################################
-def write_group(ofile,lang,gname,group):
+def write_group(ofile,lang,gname,group,refs):
 ###############################################################################
     """
     Write constants from a single group
@@ -109,10 +109,13 @@ def write_group(ofile,lang,gname,group):
     for c in group['entries']:
         n = c['name']
         v = c['value']
+        ref = refs[c['reference']]['short_citation']
         if lang=='cxx':
-            ofile.write (f'constexpr double {n} = {v};\n')
+            line = f'constexpr double {n} = {v};'
+            ofile.write(f'{line:<70} // {ref}\n')
         elif lang=='f90':
-            ofile.write (f'    real(dp), parameter :: {n} = {v}_dp\n')
+            line = f'    real(dp), parameter :: {n} = {v}_dp'
+            ofile.write(f'{line:<70} ! {ref}\n')
         else:
             raise RuntimeError(f'Missing implementation for language {lang}')
 
@@ -149,7 +152,7 @@ def generate_file(lang, groups, filename):
         # Content, by group
         for gname,group in groups_in_file.items():
             if groups is None or gname in groups:
-                write_group(ofile,lang,gname,group)
+                write_group(ofile,lang,gname,group,constants_dict['references'])
 
         # Footer
         write_footer (ofile,lang)


### PR DESCRIPTION
Allows users to see where the constant was taken, simply looking at the src code, rather than having to go to the pcd yaml file

---

Example output:

```c++
// mathematical constants
constexpr double pi = 3.141592653589793;                               // Abramowitz A., Stegun I.A., (1964)
constexpr double e = 2.718281828459045;                                // Abramowitz A., Stegun I.A., (1964)
constexpr double em_gamma = 0.5772156649015329;                        // Abramowitz A., Stegun I.A., (1964)
constexpr double radian = 57.29577951308232;                           // Abramowitz A., Stegun I.A., (1964)
constexpr double degree = 0.017453292519943295;                        // Abramowitz A., Stegun I.A., (1964)
constexpr double square_root_of_2 = 1.4142135623730951;                // Abramowitz A., Stegun I.A., (1964)
constexpr double square_root_of_3 = 1.7320508075688772;                // Abramowitz A., Stegun I.A., (1964)

// universal_physical constants
constexpr double speed_of_light_in_vacuum = 299792458;                 // CODATA (2022)
constexpr double newtonian_gravitation_constant = 6.6743e-11;          // CODATA (2022)
constexpr double standard_acceleration_of_gravity = 9.80665;           // CODATA (2022)
constexpr double standard_atmosphere = 101325;                         // CODATA (2022)
constexpr double avogadro_constant = 6.02214076e+23;                   // CODATA (2022)
constexpr double boltzmann_constant = 1.380649e-23;                    // CODATA (2022)
constexpr double stefan_boltzmann_constant = 5.670374419e-08;          // CODATA (2022)
constexpr double planck_constant = 6.62607015e-34;                     // CODATA (2022)
constexpr double molar_gas_constant = 8.314462618;                     // CODATA (2022)
constexpr double molar_volume_of_ideal_gas = 0.02271095464;            // CODATA (2022)

// earth_physical constants
constexpr double geocentric_gravitational_constant = 3986005E+08;      // Moritz H., et al., (2000)
constexpr double semimajor_axis = 6378137;                             // Moritz H., et al., (2000)
constexpr double dynamic_form_factor = 108263E-08;                     // Moritz H., et al., (2000)
constexpr double angular_velocity = 7292115E-11;                       // Moritz H., et al., (2000)
```

@rljacob I added the new "short_citation" entry to the pcd dictionary. Feel free to suggest different short citation strings, if the ones I used are not "familiar enough" for climate folks.