### PR TITLE
Add constants from `shr_const_mod.F90` and from Omega

### DIFF
--- a/pcd.yaml
+++ b/pcd.yaml
@@ -474,7 +474,6 @@ physical_constants_dictionary:
             units: K
             prec: double
             type: strict
-            uncertainty: exact
             reference: SI_Brochure_2019
             description: "
               Reference freezing point temperature of pure water at standard
@@ -485,7 +484,6 @@ physical_constants_dictionary:
             units: kg m-3
             prec: double
             type: strict
-            uncertainty: exact
             reference: UNRESOLVED_PENDING_REVIEW
             description: "
               Conventional reference density of freshwater used in coupled
@@ -497,7 +495,6 @@ physical_constants_dictionary:
             units: J kg-1 K-1
             prec: double
             type: strict
-            uncertainty: exact
             reference: UNRESOLVED_PENDING_REVIEW
             description: "
               Conventional reference specific heat capacity of freshwater.
@@ -513,7 +510,6 @@ physical_constants_dictionary:
             units: kg m-3
             prec: double
             type: strict
-            uncertainty: exact
             reference: UNRESOLVED_PENDING_REVIEW
             description: "
               Reference dry-air density.
@@ -523,10 +519,120 @@ physical_constants_dictionary:
             units: J kg-1 K-1
             prec: double
             type: strict
-            uncertainty: exact
             reference: UNRESOLVED_PENDING_REVIEW
             description: "
               Reference specific heat capacity of dry air at constant pressure.
+            "
+          - name: dry_air_molar_mass_reference
+            value: 28.966
+            units: g mol-1
+            prec: double
+            type: strict
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Reference molar mass of dry air used in atmospheric
+              thermodynamic parameterizations.
+            "
+          - name: water_vapor_molar_mass_reference
+            value: 18.016
+            units: g mol-1
+            prec: double
+            type: strict
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Reference molar mass of water vapor used in atmospheric
+              thermodynamic parameterizations.
+            "
+          - name: dry_air_specific_gas_constant_reference
+            value: 287.042
+            units: J kg-1 K-1
+            prec: double
+            type: strict
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Derived constant. Defined as molar_gas_constant / dry_air_molar_mass,
+              with molar mass converted from g mol-1 to kg mol-1.
+            "
+          - name: water_vapor_specific_gas_constant_reference
+            value: 461.505
+            units: J kg-1 K-1
+            prec: double
+            type: strict
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Derived constant. Defined as molar_gas_constant /
+              water_vapor_molar_mass_reference, with molar mass converted from
+              g mol-1 to kg mol-1.
+            "
+          - name: water_vapor_to_dry_air_gas_constant_ratio_minus_one
+            value: 0.607793
+            units: none
+            prec: double
+            type: strict
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Derived constant. Defined as
+              water_vapor_specific_gas_constant_reference /
+              dry_air_specific_gas_constant_reference - 1.
+            "
+          - name: dry_air_density_at_standard_temperature_and_pressure
+            value: 1.29232
+            units: kg m-3
+            prec: double
+            type: strict
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Derived constant. Defined as standard_atmosphere /
+              (dry_air_specific_gas_constant_reference *
+              freshwater_freezing_temperature).
+            "
+          - name: water_vapor_specific_heat_capacity_reference
+            value: 1810.0
+            units: J kg-1 K-1
+            prec: double
+            type: strict
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Reference specific heat capacity of water vapor used in
+              atmospheric thermodynamic parameterizations.
+            "
+          - name: water_vapor_to_dry_air_specific_heat_capacity_ratio_minus_one
+            value: 0.80164
+            units: none
+            prec: double
+            type: strict
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Derived constant. Defined as
+              water_vapor_specific_heat_capacity_reference /
+              dry_air_specific_heat_capacity_reference - 1.
+            "
+          - name: carbon_molar_mass_reference
+            value: 12.0107
+            units: g mol-1
+            prec: double
+            type: strict
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Reference molar mass of elemental carbon.
+            "
+          - name: oxygen_molar_mass_reference
+            value: 15.9994
+            units: g mol-1
+            prec: double
+            type: strict
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Reference molar mass of elemental oxygen.
+            "
+          - name: carbon_dioxide_molar_mass_reference
+            value: 44.0095
+            units: g mol-1
+            prec: double
+            type: strict
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Reference molar mass of carbon dioxide.
             "
     - ocean:
         description: "
@@ -539,7 +645,6 @@ physical_constants_dictionary:
             units: K
             prec: double
             type: strict
-            uncertainty: exact
             reference: UNRESOLVED_PENDING_REVIEW
             description: "
               Reference seawater freezing temperature.
@@ -549,7 +654,6 @@ physical_constants_dictionary:
             units: kg m-3
             prec: double
             type: strict
-            uncertainty: exact
             reference: UNRESOLVED_PENDING_REVIEW
             description: "
               Reference seawater density.
@@ -559,7 +663,6 @@ physical_constants_dictionary:
             units: J kg-1 K-1
             prec: double
             type: strict
-            uncertainty: exact
             reference: UNRESOLVED_PENDING_REVIEW
             description: "
               Reference seawater specific heat capacity.
@@ -569,7 +672,6 @@ physical_constants_dictionary:
             units: g kg-1
             prec: double
             type: strict
-            uncertainty: exact
             reference: UNRESOLVED_PENDING_REVIEW
             description: "
               Reference ocean salinity.
@@ -579,7 +681,6 @@ physical_constants_dictionary:
             units: m s-1
             prec: double
             type: strict
-            uncertainty: exact
             reference: UNRESOLVED_PENDING_REVIEW
             description: "
               Typical reference speed of sound in seawater.
@@ -595,7 +696,6 @@ physical_constants_dictionary:
             units: kg m-3
             prec: double
             type: strict
-            uncertainty: exact
             reference: UNRESOLVED_PENDING_REVIEW
             description: "
               Reference density of sea ice.
@@ -605,7 +705,6 @@ physical_constants_dictionary:
             units: J kg-1 K-1
             prec: double
             type: strict
-            uncertainty: exact
             reference: UNRESOLVED_PENDING_REVIEW
             description: "
               Reference specific heat capacity of ice.
@@ -615,7 +714,6 @@ physical_constants_dictionary:
             units: W m-1 K-1
             prec: double
             type: strict
-            uncertainty: exact
             reference: UNRESOLVED_PENDING_REVIEW
             description: "
               Reference thermal conductivity of ice.
@@ -625,10 +723,20 @@ physical_constants_dictionary:
             units: g kg-1
             prec: double
             type: strict
-            uncertainty: exact
             reference: UNRESOLVED_PENDING_REVIEW
             description: "
               Reference sea-ice salinity.
+            "
+          - name: ice_thermal_diffusivity_reference
+            value: 1.08162E-06
+            units: m2 s-1
+            prec: double
+            type: strict
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Derived constant. Defined as
+              ice_thermal_conductivity_reference /
+              (ice_density_reference * ice_specific_heat_capacity_reference).
             "
     - coupled_phase_change:
         description: "
@@ -641,7 +749,6 @@ physical_constants_dictionary:
             units: J kg-1
             prec: double
             type: strict
-            uncertainty: exact
             reference: UNRESOLVED_PENDING_REVIEW
             description: "
               Reference latent heat released during freezing or absorbed during
@@ -652,7 +759,6 @@ physical_constants_dictionary:
             units: J kg-1
             prec: double
             type: strict
-            uncertainty: exact
             reference: UNRESOLVED_PENDING_REVIEW
             description: "
               Reference latent heat required to convert liquid water to vapor.
@@ -662,8 +768,79 @@ physical_constants_dictionary:
             units: J kg-1
             prec: double
             type: strict
-            uncertainty: exact
             reference: UNRESOLVED_PENDING_REVIEW
             description: "
-              Reference latent heat for direct ice-to-vapor phase change.
+              Derived constant. Defined as latent_heat_of_fusion_reference +
+              latent_heat_of_vaporization_reference.
+            "
+    - isotopic_standards:
+        description: "
+          Isotopic ratio and fraction standards used across Earth system components
+        "
+        entries:
+          - name: pee_dee_belemnite_ratio_13c_to_12c
+            value: 0.0112372
+            units: none
+            prec: double
+            type: strict
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Reference isotopic ratio 13C/12C for the Pee Dee Belemnite carbon
+              isotope standard.
+            "
+          - name: vsmow_ratio_18o_to_16o
+            value: 2005.2E-6
+            units: none
+            prec: double
+            type: strict
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Isotopic ratio 18O/16O in Vienna Standard Mean Ocean Water (VSMOW).
+            "
+          - name: vsmow_ratio_17o_to_16o
+            value: 379.0E-6
+            units: none
+            prec: double
+            type: strict
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Isotopic ratio 17O/16O in Vienna Standard Mean Ocean Water (VSMOW).
+            "
+          - name: vsmow_fraction_16o_of_total_oxygen
+            value: 0.997628
+            units: none
+            prec: double
+            type: strict
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Isotopic fraction of 16O in total oxygen for Vienna Standard Mean
+              Ocean Water (VSMOW).
+            "
+          - name: vsmow_ratio_2h_to_1h
+            value: 155.76E-6
+            units: none
+            prec: double
+            type: strict
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Isotopic ratio 2H/1H in Vienna Standard Mean Ocean Water (VSMOW).
+            "
+          - name: vsmow_ratio_3h_to_1h
+            value: 1.85E-6
+            units: none
+            prec: double
+            type: strict
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Isotopic ratio 3H/1H in Vienna Standard Mean Ocean Water (VSMOW).
+            "
+          - name: vsmow_fraction_1h_of_total_hydrogen
+            value: 0.99984426
+            units: none
+            prec: double
+            type: strict
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Isotopic fraction of 1H in total hydrogen for Vienna Standard Mean
+              Ocean Water (VSMOW).
             "

--- a/pcd.yaml
+++ b/pcd.yaml
@@ -47,34 +47,35 @@ physical_constants_dictionary:
         Properties of Ordinary Water Substance for General and Scientific Use,
         J. Phys. Chem. Ref. Data, 31, 387-535, 2002.
       "
-    SI_Brochure_2019:
+    SI2019:
       description: "SI brochure defining units and accepted non-SI units"
       citation: "
         Bureau International des Poids et Mesures (BIPM), The International
         System of Units (SI), 9th edition, 2019.
       "
-    TEOS10_2010:
-      description: "TEOS-10 manual for seawater thermodynamic properties"
+    CGPM1948_1954:
+      description: "CGPM resolutions linking the triple point and the 0.01 degree offset"
       citation: "
-        Intergovernmental Oceanographic Commission, Scientific Committee on
-        Oceanic Research, and International Association for the Physical Sciences
-        of the Oceans, The International Thermodynamic Equation of Seawater - 2010:
-        Calculation and Use of Thermodynamic Properties, IOC Manuals and Guides No. 56,
-        UNESCO, 2010.
+        9th CGPM (1948), Resolution 3, stating that the zero of the centesimal
+        thermodynamic scale is 0.0100 degree below the triple point of water
+        (DOI: 10.59161/CGPM1948RES3E);
+        and 10th CGPM (1954), Resolution 3, assigning the triple point of water
+        the exact temperature 273.16 kelvin
+        (DOI: 10.59161/CGPM1954RES3E).
       "
-    US_Standard_Atmosphere_1976:
+    US_StdAtm_1976:
       description: "U.S. Standard Atmosphere reference state values"
       citation: "
         NOAA, NASA, and USAF, U.S. Standard Atmosphere, 1976,
         U.S. Government Printing Office, Washington, D.C., 1976.
       "
-    CRC_Handbook_2018:
+    CRC2018:
       description: "CRC handbook tabulations for thermophysical properties"
       citation: "
         Rumble, J. R. (ed.), CRC Handbook of Chemistry and Physics,
         99th Edition, CRC Press, 2018.
       "
-    Smithsonian_Meteorological_Tables:
+    Smithsonian1951:
       description: "Smithsonian meteorological tables with latent-heat tabulations"
       citation: "
         List, R. J., Smithsonian Meteorological Tables,
@@ -87,18 +88,51 @@ physical_constants_dictionary:
         International Geophysics Series, Vol. 30,
         Academic Press, 1982.
       "
-    Yen_1981:
-      description: "Sea ice and freshwater ice thermophysical properties review"
+    Levitus1982:
+      description: "Climatological atlas source for world-ocean salinity fields"
       citation: "
-        Yen, Y.-C., Review of Thermal Properties of Snow, Ice and Sea Ice,
-        U.S. Army Cold Regions Research and Engineering Laboratory Report 81-10,
-        1981.
+        Levitus, S., Climatological Atlas of the World Ocean,
+        NOAA Professional Paper 13, U.S. Department of Commerce, 1982.
       "
-    UNRESOLVED_PENDING_REVIEW:
-      description: "Placeholder reference for constants pending source verification"
+    IUPAC1997:
+      description: "IUPAC Commission on Atomic Weights and Isotopic Abundances, 1997 table"
       citation: "
-        Placeholder only: authoritative citation and exact value/source pairing
-        pending project review. Do not treat as validated provenance.
+        IUPAC Commission on Atomic Weights and Isotopic Abundances,
+        Atomic Weights of the Elements 1997,
+        Pure Appl. Chem., 71(8), 1593-1607, 1999.
+        doi:10.1351/pac199971081593.
+      "
+    Untersteiner1961:
+      description: "Arctic sea-ice mass and heat budget study"
+      citation: "
+        Untersteiner, N., On the Mass and Heat Budget of Arctic Sea Ice,
+        Archiv für Meteorologie, Geophysik und Bioklimatologie, Serie A, 1961.
+      "
+    MaykutUntersteiner1971:
+      description: "Time-dependent thermodynamic sea-ice model results"
+      citation: "
+        Maykut, G. A., and N. Untersteiner, Some results from a time-dependent
+        thermodynamic model of sea ice, Journal of Geophysical Research,
+        76(6), 1550-1575, 1971.
+      "
+    CuffeyPaterson2010:
+      description: "Glaciology textbook reference for ice physical properties"
+      citation: "
+        Cuffey, K. M., and W. S. B. Paterson, The Physics of Glaciers,
+        4th ed., Butterworth-Heinemann, 2010.
+      "
+    IAEA1995:
+      description: "IAEA reference materials for stable isotopes of light elements"
+      citation: "
+        IAEA, Reference and intercomparison materials for stable isotopes of
+        light elements, IAEA-TECDOC-825, Vienna, 1995.
+      "
+    Craig1957:
+      description: "Isotopic standards for carbon and oxygen"
+      citation: "
+        Craig, H., Isotopic standards for carbon and oxygen and correction
+        factors for mass-spectrometric analysis of carbon dioxide,
+        Geochimica et Cosmochimica Acta, 12(1-2), 133-149, 1957.
       "
 
   set:
@@ -493,10 +527,11 @@ physical_constants_dictionary:
             units: K
             prec: double
             type: strict
-            reference: SI_Brochure_2019
+            reference: CGPM1948_1954
             description: "
-              Reference freezing point temperature of pure water at standard
-              atmospheric pressure.
+              Conventional 0 °C reference temperature in kelvin (273.15 K),
+              linked historically to the water-triple-point definition and the
+              0.01 degree centesimal offset.
             "
           - name: freshwater_density_reference
             value: 1000.0
@@ -514,7 +549,7 @@ physical_constants_dictionary:
             units: J kg-1 K-1
             prec: double
             type: strict
-            reference: Smithsonian_Meteorological_Tables
+            reference: Smithsonian1951
             description: "
               Conventional reference specific heat capacity of freshwater.
             "
@@ -529,7 +564,7 @@ physical_constants_dictionary:
             units: kg mol-1
             prec: double
             type: strict
-            reference: Smithsonian_Meteorological_Tables
+            reference: Smithsonian1951
             description: "
               Reference molar mass of dry air used in atmospheric
               thermodynamic parameterizations.
@@ -539,7 +574,7 @@ physical_constants_dictionary:
             units: kg mol-1
             prec: double
             type: strict
-            reference: Smithsonian_Meteorological_Tables
+            reference: Smithsonian1951
             description: "
               Reference molar mass of water vapor used in atmospheric
               thermodynamic parameterizations.
@@ -549,7 +584,7 @@ physical_constants_dictionary:
             units: J kg-1 K-1
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: US_StdAtm_1976
             description: "
               Derived constant. Defined as molar_gas_constant /
               dry_air_molar_mass_reference.
@@ -559,28 +594,17 @@ physical_constants_dictionary:
             units: J kg-1 K-1
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: US_StdAtm_1976
             description: "
               Derived constant. Defined as molar_gas_constant /
               water_vapor_molar_mass_reference.
-            "
-          - name: water_vapor_to_dry_air_gas_constant_ratio_minus_one
-            value: 0.60779307282415629
-            units: none
-            prec: double
-            type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
-            description: "
-              Derived constant. Defined as
-              water_vapor_specific_gas_constant_reference /
-              dry_air_specific_gas_constant_reference - 1.
             "
           - name: dry_air_density_at_standard_temperature_and_pressure
             value: 1.2923190576466714
             units: kg m-3
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: US_StdAtm_1976
             description: "
               Derived constant. Defined as standard_atmosphere /
               (dry_air_specific_gas_constant_reference *
@@ -591,7 +615,7 @@ physical_constants_dictionary:
             units: J kg-1 K-1
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: Smithsonian1951
             description: "
               Reference specific heat capacity of dry air at constant pressure.
             "
@@ -600,28 +624,17 @@ physical_constants_dictionary:
             units: J kg-1 K-1
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: Smithsonian1951
             description: "
               Reference specific heat capacity of water vapor used in
               atmospheric thermodynamic parameterizations.
-            "
-          - name: water_vapor_to_dry_air_specific_heat_capacity_ratio_minus_one
-            value: 0.80164038859691034
-            units: none
-            prec: double
-            type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
-            description: "
-              Derived constant. Defined as
-              water_vapor_specific_heat_capacity_reference /
-              dry_air_specific_heat_capacity_reference - 1.
             "
           - name: carbon_molar_mass_reference
             value: 0.0120107
             units: kg mol-1
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: IUPAC1997
             description: "
               Reference molar mass of elemental carbon.
             "
@@ -630,7 +643,7 @@ physical_constants_dictionary:
             units: kg mol-1
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: IUPAC1997
             description: "
               Reference molar mass of elemental oxygen.
             "
@@ -639,9 +652,10 @@ physical_constants_dictionary:
             units: kg mol-1
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: IUPAC1997
             description: "
-              Reference molar mass of carbon dioxide.
+              Derived from IUPAC standard atomic weights as
+              carbon_molar_mass_reference + 2*oxygen_molar_mass_reference.
             "
     - ocean:
         description: "
@@ -649,30 +663,22 @@ physical_constants_dictionary:
           processes, and used across coupled components
         "
         entries:
-          - name: seawater_freezing_temperature_reference
-            value: 271.35
-            units: K
-            prec: double
-            type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
-            description: "
-              Reference seawater freezing temperature.
-            "
           - name: seawater_density_reference
             value: 1026.0
             units: kg m-3
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: Gill_1982
             description: "
-              Reference seawater density.
+              Canonical reference-scale seawater density; model adopts
+              1026 kg m-3.
             "
           - name: seawater_specific_heat_capacity_reference
             value: 3996.0
             units: J kg-1 K-1
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: Gill_1982
             description: "
               Reference seawater specific heat capacity.
             "
@@ -681,7 +687,7 @@ physical_constants_dictionary:
             units: g kg-1
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: Levitus1982
             description: "
               Reference ocean salinity.
             "
@@ -690,7 +696,7 @@ physical_constants_dictionary:
             units: m s-1
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: Gill_1982
             description: "
               Typical reference speed of sound in seawater.
             "
@@ -705,16 +711,16 @@ physical_constants_dictionary:
             units: kg m-3
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: Smithsonian1951
             description: "
               Reference density of sea ice.
             "
           - name: ice_specific_heat_capacity_reference
-            value: 2108.0
+            value: 2117.27
             units: J kg-1 K-1
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: Smithsonian1951
             description: "
               Reference specific heat capacity of ice.
             "
@@ -723,7 +729,7 @@ physical_constants_dictionary:
             units: W m-1 K-1
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: MaykutUntersteiner1971
             description: "
               Reference thermal conductivity of ice.
             "
@@ -732,7 +738,7 @@ physical_constants_dictionary:
             units: g kg-1
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: Untersteiner1961
             description: "
               Reference sea-ice salinity.
             "
@@ -741,7 +747,7 @@ physical_constants_dictionary:
             units: m2 s-1
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: CuffeyPaterson2010
             description: "
               Derived constant. Defined as
               ice_thermal_conductivity_reference /
@@ -758,7 +764,7 @@ physical_constants_dictionary:
             units: J kg-1
             prec: double
             type: strict
-            reference: CRC_Handbook_2018
+            reference: CRC2018
             description: "
               Reference latent heat released during freezing or absorbed during
               melting of water.
@@ -768,7 +774,7 @@ physical_constants_dictionary:
             units: J kg-1
             prec: double
             type: strict
-            reference: Smithsonian_Meteorological_Tables
+            reference: Smithsonian1951
             description: "
               Reference latent heat required to convert liquid water to vapor.
             "
@@ -777,7 +783,7 @@ physical_constants_dictionary:
             units: J kg-1
             prec: double
             type: strict
-            reference: Smithsonian_Meteorological_Tables
+            reference: Smithsonian1951
             description: "
               Derived constant. Defined as latent_heat_of_fusion_reference +
               latent_heat_of_vaporization_reference.
@@ -792,7 +798,7 @@ physical_constants_dictionary:
             units: none
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: Craig1957
             description: "
               Reference isotopic ratio 13C/12C for the Pee Dee Belemnite carbon
               isotope standard.
@@ -802,7 +808,7 @@ physical_constants_dictionary:
             units: none
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: IAEA1995
             description: "
               Isotopic ratio 18O/16O in Vienna Standard Mean Ocean Water (VSMOW).
             "
@@ -811,7 +817,7 @@ physical_constants_dictionary:
             units: none
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: IAEA1995
             description: "
               Isotopic ratio 17O/16O in Vienna Standard Mean Ocean Water (VSMOW).
             "
@@ -820,7 +826,7 @@ physical_constants_dictionary:
             units: none
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: IAEA1995
             description: "
               Isotopic fraction of 16O in total oxygen for Vienna Standard Mean
               Ocean Water (VSMOW).
@@ -830,7 +836,7 @@ physical_constants_dictionary:
             units: none
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: IAEA1995
             description: "
               Isotopic ratio 2H/1H in Vienna Standard Mean Ocean Water (VSMOW).
             "
@@ -839,7 +845,7 @@ physical_constants_dictionary:
             units: none
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: IAEA1995
             description: "
               Isotopic ratio 3H/1H in Vienna Standard Mean Ocean Water (VSMOW).
             "
@@ -848,7 +854,7 @@ physical_constants_dictionary:
             units: none
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: IAEA1995
             description: "
               Isotopic fraction of 1H in total hydrogen for Vienna Standard Mean
               Ocean Water (VSMOW).

--- a/pcd.yaml
+++ b/pcd.yaml
@@ -10,7 +10,7 @@
 #
 
 physical_constants_dictionary:
-  version_number: 0.0.2
+  version_number: 0.1.0
   institution: E3SM Project
   description: Community-based dictionary for consistent physical constant sets
   contact: E3SM Project

--- a/pcd.yaml
+++ b/pcd.yaml
@@ -47,6 +47,40 @@ physical_constants_dictionary:
         Properties of Ordinary Water Substance for General and Scientific Use,
         J. Phys. Chem. Ref. Data, 31, 387-535, 2002.
       "
+    SI_Brochure_2019:
+      description: "SI brochure defining units and accepted non-SI units"
+      citation: "
+        Bureau International des Poids et Mesures (BIPM), The International
+        System of Units (SI), 9th edition, 2019.
+      "
+    TEOS10_2010:
+      description: "TEOS-10 manual for seawater thermodynamic properties"
+      citation: "
+        Intergovernmental Oceanographic Commission, Scientific Committee on
+        Oceanic Research, and International Association for the Physical Sciences
+        of the Oceans, The International Thermodynamic Equation of Seawater - 2010:
+        Calculation and Use of Thermodynamic Properties, IOC Manuals and Guides No. 56,
+        UNESCO, 2010.
+      "
+    US_Standard_Atmosphere_1976:
+      description: "U.S. Standard Atmosphere reference state values"
+      citation: "
+        NOAA, NASA, and USAF, U.S. Standard Atmosphere, 1976,
+        U.S. Government Printing Office, Washington, D.C., 1976.
+      "
+    Yen_1981:
+      description: "Sea ice and freshwater ice thermophysical properties review"
+      citation: "
+        Yen, Y.-C., Review of Thermal Properties of Snow, Ice and Sea Ice,
+        U.S. Army Cold Regions Research and Engineering Laboratory Report 81-10,
+        1981.
+      "
+    UNRESOLVED_PENDING_REVIEW:
+      description: "Placeholder reference for constants pending source verification"
+      citation: "
+        Placeholder only: authoritative citation and exact value/source pairing
+        pending project review. Do not treat as validated provenance.
+      "
 
   set:
     - mathematical:
@@ -203,7 +237,7 @@ physical_constants_dictionary:
             reference: NIST_CODATA2022
             description: "
               Proportionality constant between the power emitted by
-              a black body and the fourth power of its temperature, 
+              a black body and the fourth power of its temperature,
               according to Stefan-Boltzmann's law.
             "
 
@@ -338,7 +372,7 @@ physical_constants_dictionary:
             reference: GRS80
             description: "
               Radius of Earth's reference sphere with same surface as ellipsoid's.
-              Derived constant
+              Derived constant.
             "
           - name: radius_of_sphere_of_same_volume
             value: 6371000.7900
@@ -434,4 +468,202 @@ physical_constants_dictionary:
             description: "
               Triple point density of vapor H2O.
               Calculated from Eq. (6.4).
+            "
+          - name: freshwater_freezing_temperature
+            value: 273.15
+            units: K
+            prec: double
+            type: strict
+            uncertainty: exact
+            reference: SI_Brochure_2019
+            description: "
+              Reference freezing point temperature of pure water at standard
+              atmospheric pressure.
+            "
+          - name: freshwater_density_reference
+            value: 1000.0
+            units: kg m-3
+            prec: double
+            type: strict
+            uncertainty: exact
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Conventional reference density of freshwater used in coupled
+              modeling; this is an approximation and not an exact
+              thermodynamic density at a specific state point.
+            "
+          - name: freshwater_specific_heat_capacity_reference
+            value: 4188.0
+            units: J kg-1 K-1
+            prec: double
+            type: strict
+            uncertainty: exact
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Conventional reference specific heat capacity of freshwater.
+            "
+    - atmosphere:
+        description: "
+          Thermophysical reference constants primarily associated with
+          atmospheric processes, and used across coupled components
+        "
+        entries:
+          - name: dry_air_density_reference
+            value: 1.2
+            units: kg m-3
+            prec: double
+            type: strict
+            uncertainty: exact
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Reference dry-air density.
+            "
+          - name: dry_air_specific_heat_capacity_reference
+            value: 1005.0
+            units: J kg-1 K-1
+            prec: double
+            type: strict
+            uncertainty: exact
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Reference specific heat capacity of dry air at constant pressure.
+            "
+    - ocean:
+        description: "
+          Thermophysical reference constants primarily associated with ocean
+          processes, and used across coupled components
+        "
+        entries:
+          - name: seawater_freezing_temperature_reference
+            value: 271.35
+            units: K
+            prec: double
+            type: strict
+            uncertainty: exact
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Reference seawater freezing temperature.
+            "
+          - name: seawater_density_reference
+            value: 1026.0
+            units: kg m-3
+            prec: double
+            type: strict
+            uncertainty: exact
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Reference seawater density.
+            "
+          - name: seawater_specific_heat_capacity_reference
+            value: 3996.0
+            units: J kg-1 K-1
+            prec: double
+            type: strict
+            uncertainty: exact
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Reference seawater specific heat capacity.
+            "
+          - name: ocean_reference_salinity
+            value: 34.7
+            units: g kg-1
+            prec: double
+            type: strict
+            uncertainty: exact
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Reference ocean salinity.
+            "
+          - name: speed_of_sound_in_seawater_reference
+            value: 1500.0
+            units: m s-1
+            prec: double
+            type: strict
+            uncertainty: exact
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Typical reference speed of sound in seawater.
+            "
+    - sea_ice:
+        description: "
+          Thermophysical reference constants primarily associated with sea-ice
+          processes, and used across coupled components
+        "
+        entries:
+          - name: ice_density_reference
+            value: 917.0
+            units: kg m-3
+            prec: double
+            type: strict
+            uncertainty: exact
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Reference density of sea ice.
+            "
+          - name: ice_specific_heat_capacity_reference
+            value: 2108.0
+            units: J kg-1 K-1
+            prec: double
+            type: strict
+            uncertainty: exact
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Reference specific heat capacity of ice.
+            "
+          - name: ice_thermal_conductivity_reference
+            value: 2.1
+            units: W m-1 K-1
+            prec: double
+            type: strict
+            uncertainty: exact
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Reference thermal conductivity of ice.
+            "
+          - name: sea_ice_reference_salinity
+            value: 4.0
+            units: g kg-1
+            prec: double
+            type: strict
+            uncertainty: exact
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Reference sea-ice salinity.
+            "
+    - coupled_phase_change:
+        description: "
+          Reference constants for phase-change processes coupling atmosphere,
+          ocean, and sea-ice components
+        "
+        entries:
+          - name: latent_heat_of_fusion_reference
+            value: 333700.0
+            units: J kg-1
+            prec: double
+            type: strict
+            uncertainty: exact
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Reference latent heat released during freezing or absorbed during
+              melting of water.
+            "
+          - name: latent_heat_of_vaporization_reference
+            value: 2501000.0
+            units: J kg-1
+            prec: double
+            type: strict
+            uncertainty: exact
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Reference latent heat required to convert liquid water to vapor.
+            "
+          - name: latent_heat_of_sublimation_reference
+            value: 2834700.0
+            units: J kg-1
+            prec: double
+            type: strict
+            uncertainty: exact
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Reference latent heat for direct ice-to-vapor phase change.
             "

--- a/pcd.yaml
+++ b/pcd.yaml
@@ -68,6 +68,25 @@ physical_constants_dictionary:
         NOAA, NASA, and USAF, U.S. Standard Atmosphere, 1976,
         U.S. Government Printing Office, Washington, D.C., 1976.
       "
+    CRC_Handbook_2018:
+      description: "CRC handbook tabulations for thermophysical properties"
+      citation: "
+        Rumble, J. R. (ed.), CRC Handbook of Chemistry and Physics,
+        99th Edition, CRC Press, 2018.
+      "
+    Smithsonian_Meteorological_Tables:
+      description: "Smithsonian meteorological tables with latent-heat tabulations"
+      citation: "
+        List, R. J., Smithsonian Meteorological Tables,
+        Smithsonian Institution, Washington, D.C., 1951.
+      "
+    Gill_1982:
+      description: "Atmosphere-Ocean Dynamics textbook with canonical Boussinesq scaling"
+      citation: "
+        Gill, A. E., Atmosphere-Ocean Dynamics,
+        International Geophysics Series, Vol. 30,
+        Academic Press, 1982.
+      "
     Yen_1981:
       description: "Sea ice and freshwater ice thermophysical properties review"
       citation: "
@@ -407,8 +426,8 @@ physical_constants_dictionary:
         "
         entries:
           - name: water_molar_mass
-            value: 18.015268
-            units: g mol-1
+            value: 0.018015268
+            units: kg mol-1
             prec: double
             type: strict
             uncertainty: exact
@@ -484,7 +503,7 @@ physical_constants_dictionary:
             units: kg m-3
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: Gill_1982
             description: "
               Conventional reference density of freshwater used in coupled
               modeling; this is an approximation and not an exact
@@ -495,7 +514,7 @@ physical_constants_dictionary:
             units: J kg-1 K-1
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: Smithsonian_Meteorological_Tables
             description: "
               Conventional reference specific heat capacity of freshwater.
             "
@@ -505,67 +524,48 @@ physical_constants_dictionary:
           atmospheric processes, and used across coupled components
         "
         entries:
-          - name: dry_air_density_reference
-            value: 1.2
-            units: kg m-3
-            prec: double
-            type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
-            description: "
-              Reference dry-air density.
-            "
-          - name: dry_air_specific_heat_capacity_reference
-            value: 1005.0
-            units: J kg-1 K-1
-            prec: double
-            type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
-            description: "
-              Reference specific heat capacity of dry air at constant pressure.
-            "
           - name: dry_air_molar_mass_reference
-            value: 28.966
-            units: g mol-1
+            value: 0.028966
+            units: kg mol-1
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: Smithsonian_Meteorological_Tables
             description: "
               Reference molar mass of dry air used in atmospheric
               thermodynamic parameterizations.
             "
           - name: water_vapor_molar_mass_reference
-            value: 18.016
-            units: g mol-1
+            value: 0.018016
+            units: kg mol-1
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: Smithsonian_Meteorological_Tables
             description: "
               Reference molar mass of water vapor used in atmospheric
               thermodynamic parameterizations.
             "
           - name: dry_air_specific_gas_constant_reference
-            value: 287.042
-            units: J kg-1 K-1
-            prec: double
-            type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
-            description: "
-              Derived constant. Defined as molar_gas_constant / dry_air_molar_mass,
-              with molar mass converted from g mol-1 to kg mol-1.
-            "
-          - name: water_vapor_specific_gas_constant_reference
-            value: 461.505
+            value: 287.04213968100532
             units: J kg-1 K-1
             prec: double
             type: strict
             reference: UNRESOLVED_PENDING_REVIEW
             description: "
               Derived constant. Defined as molar_gas_constant /
-              water_vapor_molar_mass_reference, with molar mass converted from
-              g mol-1 to kg mol-1.
+              dry_air_molar_mass_reference.
+            "
+          - name: water_vapor_specific_gas_constant_reference
+            value: 461.50436378774424
+            units: J kg-1 K-1
+            prec: double
+            type: strict
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Derived constant. Defined as molar_gas_constant /
+              water_vapor_molar_mass_reference.
             "
           - name: water_vapor_to_dry_air_gas_constant_ratio_minus_one
-            value: 0.607793
+            value: 0.60779307282415629
             units: none
             prec: double
             type: strict
@@ -576,7 +576,7 @@ physical_constants_dictionary:
               dry_air_specific_gas_constant_reference - 1.
             "
           - name: dry_air_density_at_standard_temperature_and_pressure
-            value: 1.29232
+            value: 1.2923190576466714
             units: kg m-3
             prec: double
             type: strict
@@ -585,6 +585,15 @@ physical_constants_dictionary:
               Derived constant. Defined as standard_atmosphere /
               (dry_air_specific_gas_constant_reference *
               freshwater_freezing_temperature).
+            "
+          - name: dry_air_specific_heat_capacity_reference
+            value: 1004.64
+            units: J kg-1 K-1
+            prec: double
+            type: strict
+            reference: UNRESOLVED_PENDING_REVIEW
+            description: "
+              Reference specific heat capacity of dry air at constant pressure.
             "
           - name: water_vapor_specific_heat_capacity_reference
             value: 1810.0
@@ -597,7 +606,7 @@ physical_constants_dictionary:
               atmospheric thermodynamic parameterizations.
             "
           - name: water_vapor_to_dry_air_specific_heat_capacity_ratio_minus_one
-            value: 0.80164
+            value: 0.80164038859691034
             units: none
             prec: double
             type: strict
@@ -608,8 +617,8 @@ physical_constants_dictionary:
               dry_air_specific_heat_capacity_reference - 1.
             "
           - name: carbon_molar_mass_reference
-            value: 12.0107
-            units: g mol-1
+            value: 0.0120107
+            units: kg mol-1
             prec: double
             type: strict
             reference: UNRESOLVED_PENDING_REVIEW
@@ -617,8 +626,8 @@ physical_constants_dictionary:
               Reference molar mass of elemental carbon.
             "
           - name: oxygen_molar_mass_reference
-            value: 15.9994
-            units: g mol-1
+            value: 0.0159994
+            units: kg mol-1
             prec: double
             type: strict
             reference: UNRESOLVED_PENDING_REVIEW
@@ -626,8 +635,8 @@ physical_constants_dictionary:
               Reference molar mass of elemental oxygen.
             "
           - name: carbon_dioxide_molar_mass_reference
-            value: 44.0095
-            units: g mol-1
+            value: 0.0440095
+            units: kg mol-1
             prec: double
             type: strict
             reference: UNRESOLVED_PENDING_REVIEW
@@ -728,7 +737,7 @@ physical_constants_dictionary:
               Reference sea-ice salinity.
             "
           - name: ice_thermal_diffusivity_reference
-            value: 1.08162E-06
+            value: 1.0863739733765951E-06
             units: m2 s-1
             prec: double
             type: strict
@@ -749,7 +758,7 @@ physical_constants_dictionary:
             units: J kg-1
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: CRC_Handbook_2018
             description: "
               Reference latent heat released during freezing or absorbed during
               melting of water.
@@ -759,7 +768,7 @@ physical_constants_dictionary:
             units: J kg-1
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: Smithsonian_Meteorological_Tables
             description: "
               Reference latent heat required to convert liquid water to vapor.
             "
@@ -768,7 +777,7 @@ physical_constants_dictionary:
             units: J kg-1
             prec: double
             type: strict
-            reference: UNRESOLVED_PENDING_REVIEW
+            reference: Smithsonian_Meteorological_Tables
             description: "
               Derived constant. Defined as latent_heat_of_fusion_reference +
               latent_heat_of_vaporization_reference.

--- a/pcd.yaml
+++ b/pcd.yaml
@@ -556,14 +556,7 @@ physical_constants_dictionary:
               Triple point density of vapor H2O.
               Calculated from Eq. (6.4).
             "
-    - water_reference:
-        description: "
-          Conventional and model-reference values for water thermodynamic
-          properties that vary with state and are used across coupled Earth
-          system components.
-        "
-        entries:
-          - name: pure_water_freezing_temperature
+          - name: pure_water_freezing_temperature_reference
             value: 273.15
             units: K
             prec: double
@@ -623,7 +616,7 @@ physical_constants_dictionary:
               Derived constant. Defined as latent_heat_of_fusion_reference +
               latent_heat_of_vaporization_reference.
             "
-    - atmosphere:
+    - earth_atmosphere:
         description: "
           Thermophysical reference constants primarily associated with
           Earth's atmospheric processes, and used across coupled components
@@ -699,10 +692,10 @@ physical_constants_dictionary:
               Reference specific heat capacity of water vapor used in
               atmospheric thermodynamic parameterizations.
             "
-    - ocean:
+    - earth_seawater:
         description: "
-          Thermophysical reference constants primarily associated with Earth's
-          ocean processes, and used across coupled components
+          Thermophysical reference constants associated with seawater (both
+          liquid and solid) on Earth
         "
         entries:
           - name: seawater_density_reference
@@ -798,13 +791,7 @@ physical_constants_dictionary:
               Isotopic fraction of 1H in total hydrogen for Vienna Standard Mean
               Ocean Water (VSMOW).
             "
-    - sea_ice:
-        description: "
-          Thermophysical reference constants primarily associated with Earth's
-          sea-ice processes, and used across coupled components
-        "
-        entries:
-          - name: ice_density_reference
+          - name: sea_ice_density_reference
             value: 917.0
             units: kg m-3
             prec: double
@@ -813,23 +800,23 @@ physical_constants_dictionary:
             description: "
               Reference density of sea ice.
             "
-          - name: ice_specific_heat_capacity_reference
+          - name: sea_ice_specific_heat_capacity_reference
             value: 2117.27
             units: J kg-1 K-1
             prec: double
             type: strict
             reference: Smithsonian1951
             description: "
-              Reference specific heat capacity of ice.
+              Reference specific heat capacity of sea ice.
             "
-          - name: ice_thermal_conductivity_reference
+          - name: sea_ice_thermal_conductivity_reference
             value: 2.1
             units: W m-1 K-1
             prec: double
             type: strict
             reference: MaykutUntersteiner1971
             description: "
-              Reference thermal conductivity of ice.
+              Reference thermal conductivity of sea ice.
             "
           - name: sea_ice_reference_salinity
             value: 4.0
@@ -840,7 +827,7 @@ physical_constants_dictionary:
             description: "
               Reference sea-ice salinity.
             "
-          - name: ice_thermal_diffusivity_reference
+          - name: sea_ice_thermal_diffusivity_reference
             value: 1.0863739733765951E-06
             units: m2 s-1
             prec: double
@@ -848,8 +835,8 @@ physical_constants_dictionary:
             reference: CuffeyPaterson2010
             description: "
               Derived constant. Defined as
-              ice_thermal_conductivity_reference /
-              (ice_density_reference * ice_specific_heat_capacity_reference).
+              sea_ice_thermal_conductivity_reference /
+              (sea_ice_density_reference * sea_ice_specific_heat_capacity_reference).
             "
     - isotopic_standards:
         description: "

--- a/pcd.yaml
+++ b/pcd.yaml
@@ -328,6 +328,40 @@ physical_constants_dictionary:
               Ideal gas molar volume as computed by the ideal gas law (RT/p)
               at Standard Temperature and Pressure (STP: 273.15K, 100 kPa).
             "
+    - chemical_molar_masses:
+        description: "
+          Reference molar masses for chemical elements and compounds used
+          across model components.
+        "
+        entries:
+          - name: carbon_molar_mass_reference
+            value: 0.0120107
+            units: kg mol-1
+            prec: double
+            type: strict
+            reference: IUPAC1997
+            description: "
+              Reference molar mass of elemental carbon.
+            "
+          - name: oxygen_molar_mass_reference
+            value: 0.0159994
+            units: kg mol-1
+            prec: double
+            type: strict
+            reference: IUPAC1997
+            description: "
+              Reference molar mass of elemental oxygen.
+            "
+          - name: carbon_dioxide_molar_mass_reference
+            value: 0.0440095
+            units: kg mol-1
+            prec: double
+            type: strict
+            reference: IUPAC1997
+            description: "
+              Derived from IUPAC standard atomic weights as
+              carbon_molar_mass_reference + 2*oxygen_molar_mass_reference.
+            "
     - earth_physical:
         description: "
           Properties of the planet Earth
@@ -522,41 +556,77 @@ physical_constants_dictionary:
               Triple point density of vapor H2O.
               Calculated from Eq. (6.4).
             "
-          - name: freshwater_freezing_temperature
+    - water_reference:
+        description: "
+          Conventional and model-reference values for water thermodynamic
+          properties that vary with state and are used across coupled Earth
+          system components.
+        "
+        entries:
+          - name: pure_water_freezing_temperature
             value: 273.15
             units: K
             prec: double
             type: strict
             reference: CGPM1948_1954
             description: "
-              Conventional 0 °C reference temperature in kelvin (273.15 K),
+              Conventional 0 C reference temperature in kelvin (273.15 K),
               linked historically to the water-triple-point definition and the
               0.01 degree centesimal offset.
             "
-          - name: freshwater_density_reference
+          - name: pure_water_density_reference
             value: 1000.0
             units: kg m-3
             prec: double
             type: strict
             reference: Gill_1982
             description: "
-              Conventional reference density of freshwater used in coupled
+              Conventional reference density of pure water used in coupled
               modeling; this is an approximation and not an exact
               thermodynamic density at a specific state point.
             "
-          - name: freshwater_specific_heat_capacity_reference
+          - name: pure_water_specific_heat_capacity_reference
             value: 4188.0
             units: J kg-1 K-1
             prec: double
             type: strict
             reference: Smithsonian1951
             description: "
-              Conventional reference specific heat capacity of freshwater.
+              Conventional reference specific heat capacity of pure water.
+            "
+          - name: latent_heat_of_fusion_reference
+            value: 333700.0
+            units: J kg-1
+            prec: double
+            type: strict
+            reference: CRC2018
+            description: "
+              Reference latent heat released during freezing or absorbed during
+              melting of water.
+            "
+          - name: latent_heat_of_vaporization_reference
+            value: 2501000.0
+            units: J kg-1
+            prec: double
+            type: strict
+            reference: Smithsonian1951
+            description: "
+              Reference latent heat required to convert liquid water to vapor.
+            "
+          - name: latent_heat_of_sublimation_reference
+            value: 2834700.0
+            units: J kg-1
+            prec: double
+            type: strict
+            reference: Smithsonian1951
+            description: "
+              Derived constant. Defined as latent_heat_of_fusion_reference +
+              latent_heat_of_vaporization_reference.
             "
     - atmosphere:
         description: "
           Thermophysical reference constants primarily associated with
-          atmospheric processes, and used across coupled components
+          Earth's atmospheric processes, and used across coupled components
         "
         entries:
           - name: dry_air_molar_mass_reference
@@ -608,7 +678,7 @@ physical_constants_dictionary:
             description: "
               Derived constant. Defined as standard_atmosphere /
               (dry_air_specific_gas_constant_reference *
-              freshwater_freezing_temperature).
+              pure_water_freezing_temperature).
             "
           - name: dry_air_specific_heat_capacity_reference
             value: 1004.64
@@ -629,38 +699,10 @@ physical_constants_dictionary:
               Reference specific heat capacity of water vapor used in
               atmospheric thermodynamic parameterizations.
             "
-          - name: carbon_molar_mass_reference
-            value: 0.0120107
-            units: kg mol-1
-            prec: double
-            type: strict
-            reference: IUPAC1997
-            description: "
-              Reference molar mass of elemental carbon.
-            "
-          - name: oxygen_molar_mass_reference
-            value: 0.0159994
-            units: kg mol-1
-            prec: double
-            type: strict
-            reference: IUPAC1997
-            description: "
-              Reference molar mass of elemental oxygen.
-            "
-          - name: carbon_dioxide_molar_mass_reference
-            value: 0.0440095
-            units: kg mol-1
-            prec: double
-            type: strict
-            reference: IUPAC1997
-            description: "
-              Derived from IUPAC standard atomic weights as
-              carbon_molar_mass_reference + 2*oxygen_molar_mass_reference.
-            "
     - ocean:
         description: "
-          Thermophysical reference constants primarily associated with ocean
-          processes, and used across coupled components
+          Thermophysical reference constants primarily associated with Earth's
+          ocean processes, and used across coupled components
         "
         entries:
           - name: seawater_density_reference
@@ -699,109 +741,6 @@ physical_constants_dictionary:
             reference: Gill_1982
             description: "
               Typical reference speed of sound in seawater.
-            "
-    - sea_ice:
-        description: "
-          Thermophysical reference constants primarily associated with sea-ice
-          processes, and used across coupled components
-        "
-        entries:
-          - name: ice_density_reference
-            value: 917.0
-            units: kg m-3
-            prec: double
-            type: strict
-            reference: Smithsonian1951
-            description: "
-              Reference density of sea ice.
-            "
-          - name: ice_specific_heat_capacity_reference
-            value: 2117.27
-            units: J kg-1 K-1
-            prec: double
-            type: strict
-            reference: Smithsonian1951
-            description: "
-              Reference specific heat capacity of ice.
-            "
-          - name: ice_thermal_conductivity_reference
-            value: 2.1
-            units: W m-1 K-1
-            prec: double
-            type: strict
-            reference: MaykutUntersteiner1971
-            description: "
-              Reference thermal conductivity of ice.
-            "
-          - name: sea_ice_reference_salinity
-            value: 4.0
-            units: g kg-1
-            prec: double
-            type: strict
-            reference: Untersteiner1961
-            description: "
-              Reference sea-ice salinity.
-            "
-          - name: ice_thermal_diffusivity_reference
-            value: 1.0863739733765951E-06
-            units: m2 s-1
-            prec: double
-            type: strict
-            reference: CuffeyPaterson2010
-            description: "
-              Derived constant. Defined as
-              ice_thermal_conductivity_reference /
-              (ice_density_reference * ice_specific_heat_capacity_reference).
-            "
-    - coupled_phase_change:
-        description: "
-          Reference constants for phase-change processes coupling atmosphere,
-          ocean, and sea-ice components
-        "
-        entries:
-          - name: latent_heat_of_fusion_reference
-            value: 333700.0
-            units: J kg-1
-            prec: double
-            type: strict
-            reference: CRC2018
-            description: "
-              Reference latent heat released during freezing or absorbed during
-              melting of water.
-            "
-          - name: latent_heat_of_vaporization_reference
-            value: 2501000.0
-            units: J kg-1
-            prec: double
-            type: strict
-            reference: Smithsonian1951
-            description: "
-              Reference latent heat required to convert liquid water to vapor.
-            "
-          - name: latent_heat_of_sublimation_reference
-            value: 2834700.0
-            units: J kg-1
-            prec: double
-            type: strict
-            reference: Smithsonian1951
-            description: "
-              Derived constant. Defined as latent_heat_of_fusion_reference +
-              latent_heat_of_vaporization_reference.
-            "
-    - isotopic_standards:
-        description: "
-          Isotopic ratio and fraction standards used across Earth system components
-        "
-        entries:
-          - name: pee_dee_belemnite_ratio_13c_to_12c
-            value: 0.0112372
-            units: none
-            prec: double
-            type: strict
-            reference: Craig1957
-            description: "
-              Reference isotopic ratio 13C/12C for the Pee Dee Belemnite carbon
-              isotope standard.
             "
           - name: vsmow_ratio_18o_to_16o
             value: 2005.2E-6
@@ -858,4 +797,72 @@ physical_constants_dictionary:
             description: "
               Isotopic fraction of 1H in total hydrogen for Vienna Standard Mean
               Ocean Water (VSMOW).
+            "
+    - sea_ice:
+        description: "
+          Thermophysical reference constants primarily associated with Earth's
+          sea-ice processes, and used across coupled components
+        "
+        entries:
+          - name: ice_density_reference
+            value: 917.0
+            units: kg m-3
+            prec: double
+            type: strict
+            reference: Smithsonian1951
+            description: "
+              Reference density of sea ice.
+            "
+          - name: ice_specific_heat_capacity_reference
+            value: 2117.27
+            units: J kg-1 K-1
+            prec: double
+            type: strict
+            reference: Smithsonian1951
+            description: "
+              Reference specific heat capacity of ice.
+            "
+          - name: ice_thermal_conductivity_reference
+            value: 2.1
+            units: W m-1 K-1
+            prec: double
+            type: strict
+            reference: MaykutUntersteiner1971
+            description: "
+              Reference thermal conductivity of ice.
+            "
+          - name: sea_ice_reference_salinity
+            value: 4.0
+            units: g kg-1
+            prec: double
+            type: strict
+            reference: Untersteiner1961
+            description: "
+              Reference sea-ice salinity.
+            "
+          - name: ice_thermal_diffusivity_reference
+            value: 1.0863739733765951E-06
+            units: m2 s-1
+            prec: double
+            type: strict
+            reference: CuffeyPaterson2010
+            description: "
+              Derived constant. Defined as
+              ice_thermal_conductivity_reference /
+              (ice_density_reference * ice_specific_heat_capacity_reference).
+            "
+    - isotopic_standards:
+        description: "
+          Isotopic ratio and fraction standards used across Earth system components
+        "
+        entries:
+          - name: pee_dee_belemnite_ratio_13c_to_12c
+            value: 0.0112372
+            units: none
+            prec: double
+            type: strict
+            reference: Craig1957
+            description: "
+              Reference isotopic ratio 13C/12C for the Pee Dee Belemnite carbon
+              isotope standard.
             "


### PR DESCRIPTION
Add many more physical constants needed by multiple ESM components. Constants are taken from share/util/shr_const_mod.F90 and omega/src/ocn/GlobalConstants.h in E3SM.

---

I have made my best effort to find the sources for all the constants I added.  A few are simply canonical values that are common in ESMs, but a reasonable citation is included even in these cases.

Here is a map of variable names here to those from E3SM and Omega source files:


| pcd.yaml constant | [shr_const_mod.F90](https://github.com/E3SM-Project/E3SM/blob/master/share/util/shr_const_mod.F90) variable | [GlobalConstants.h](https://github.com/E3SM-Project/Omega/blob/develop/components/omega/src/ocn/GlobalConstants.h) variable |
| --- | --- | --- |
| `pi` | `SHR_CONST_PI` | `Pi` |
| `e` |  |  |
| `em_gamma` |  |  |
| `radian` |  | `Radian, Rad2Deg` |
| `degree` |  | `Degree, Deg2Rad` |
| `square_root_of_2` |  | `SqrtTwo` |
| `square_root_of_3` |  | `SqrtThree` |
| `speed_of_light_in_vacuum` |  |  |
| `newtonian_gravitation_constant` |  |  |
| `standard_acceleration_of_gravity` | `SHR_CONST_G` | `Gravity` |
| `standard_atmosphere` | `SHR_CONST_PSTD` | `AtmRefP` |
| `avogadro_constant` | `SHR_CONST_AVOGAD` |  |
| `boltzmann_constant` | `SHR_CONST_BOLTZ` |  |
| `stefan_boltzmann_constant` | `SHR_CONST_STEBOL` |  |
| `planck_constant` |  |  |
| `molar_gas_constant` | `SHR_CONST_RGAS` |  |
| `molar_volume_of_ideal_gas` |  |  |
| `geocentric_gravitational_constant` |  |  |
| `semimajor_axis` |  |  |
| `dynamic_form_factor` |  |  |
| `angular_velocity` | `SHR_CONST_OMEGA` | `Omega` (derived) |
| `semiminor_axis` |  |  |
| `flattening` |  |  |
| `reciprocal_flattening` |  |  |
| `mean_radius` | `SHR_CONST_REARTH` | `REarth` |
| `radius_of_sphere_of_same_surface` |  |  |
| `radius_of_sphere_of_same_volume` |  |  |
| `total_solar_irradiance` |  |  |
| `water_molar_mass` | `SHR_CONST_MWWV` |  |
| `water_specific_gas_constant` | `SHR_CONST_RWV` |  |
| `water_triple_point_temperature` | `SHR_CONST_TKTRIP` | `TkTrip` |
| `water_triple_point_pressure` |  |  |
| `liquid_water_triple_point_density` |  |  |
| `vapor_water_triple_point_density` |  |  |
| `pure_water_freezing_temperature_reference` | `SHR_CONST_TKFRZ` | `TkFrz` |
| `pure_water_density_reference` | `SHR_CONST_RHOFW` | `RhoFw` |
| `pure_water_specific_heat_capacity_reference` | `SHR_CONST_CPFW` | `CpFw` |
| `dry_air_molar_mass_reference` | `SHR_CONST_MWDAIR` |  |
| `water_vapor_molar_mass_reference` | `SHR_CONST_MWWV` |  |
| `dry_air_specific_gas_constant_reference` | `SHR_CONST_RDAIR` |  |
| `water_vapor_specific_gas_constant_reference` | `SHR_CONST_RWV` |  |
| `dry_air_density_at_standard_temperature_and_pressure` | `SHR_CONST_RHODAIR` | `RhoAir` (approx) |
| `dry_air_specific_heat_capacity_reference` | `SHR_CONST_CPDAIR` | `CpAir` (approx) |
| `water_vapor_specific_heat_capacity_reference` | `SHR_CONST_CPWV` |  |
| `carbon_molar_mass_reference` | `SHR_CONST_MWC` |  |
| `oxygen_molar_mass_reference` | `SHR_CONST_MWO` |  |
| `carbon_dioxide_molar_mass_reference` | `SHR_CONST_MWCO2` |  |
| `seawater_density_reference` | `SHR_CONST_RHOSW` | `RhoSw` |
| `seawater_specific_heat_capacity_reference` | `SHR_CONST_CPSW` | `CpSw` |
| `ocean_reference_salinity` | `SHR_CONST_OCN_REF_SAL` | `OcnRefSal` |
| `speed_of_sound_in_seawater_reference` |  | `Sound` |
| `sea_ice_density_reference` | `SHR_CONST_RHOICE` | `RhoIce` |
| `sea_ice_specific_heat_capacity_reference` | `SHR_CONST_CPICE` | `CpIce` (approx) |
| `sea_ice_thermal_conductivity_reference` | `SHR_CONST_CONDICE` | `CondIce` |
| `sea_ice_reference_salinity` | `SHR_CONST_ICE_REF_SAL` | `IceRefSal` |
| `sea_ice_thermal_diffusivity_reference` | `SHR_CONST_KAPPA_LAND_ICE` |  |
| `latent_heat_of_fusion_reference` | `SHR_CONST_LATICE` | `LatIce` |
| `latent_heat_of_vaporization_reference` | `SHR_CONST_LATVAP` | `LatVap` |
| `latent_heat_of_sublimation_reference` | `SHR_CONST_LATSUB` | `LatSub` (derived) |
| `pee_dee_belemnite_ratio_13c_to_12c` | `SHR_CONST_PDB` |  |
| `vsmow_ratio_18o_to_16o` | `SHR_CONST_VSMOW_18O` |  |
| `vsmow_ratio_17o_to_16o` | `SHR_CONST_VSMOW_17O` |  |
| `vsmow_fraction_16o_of_total_oxygen` | `SHR_CONST_VSMOW_16O` |  |
| `vsmow_ratio_2h_to_1h` | `SHR_CONST_VSMOW_D` |  |
| `vsmow_ratio_3h_to_1h` | `SHR_CONST_VSMOW_T` |  |
| `vsmow_fraction_1h_of_total_hydrogen` | `SHR_CONST_VSMOW_H` |  |